### PR TITLE
Log4jdbc driver 적용

### DIFF
--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.drivers=org.mariadb.jdbc.Driver

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -12,11 +12,11 @@
 
 		<property
 				name="driverClassName"
-				value="org.mariadb.jdbc.Driver"/>
+				value="net.sf.log4jdbc.sql.jdbcapi.DriverSpy"/>
 
 		<property
 				name="jdbcUrl"
-				value="jdbc:mariadb://antiquers.czeunykbiyt3.ap-northeast-2.rds.amazonaws.com:3306"/>
+				value="jdbc:log4jdbc:mariadb://antiquers.czeunykbiyt3.ap-northeast-2.rds.amazonaws.com:3306/antiquers"/>
 
 		<property name="username" value="admin"/>
 		<property name="password" value="antiquers"/>


### PR DESCRIPTION
log4jdbc driver 적용이 안되어있어서 추가
기존에 안됬던 이유는 log4jdbc properties에 mariadb driver 를 명시안해줘서
